### PR TITLE
Add authenticated recorder UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# repro-react-sdk
+# Repro React SDK Demo
+
+This demo application showcases an authenticated recording workflow. Users must provide
+an email and access token before they can start a recording session.
+
+## Getting started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Run the development server
+   ```bash
+   npm run dev
+   ```
+
+The recorder UI loads at `http://localhost:5173`.
+
+## Authentication flow
+
+* Click **Log in** to open the authentication modal.
+* Enter the email and token that were provisioned for your app.
+* The login request is sent to `http://localhost:4000/v1/apps/APP_bddcadcb-c70f-45fa-90f6-56413786f9b3/users/login`
+  with the `x-app-user-token` header and the same credentials in the request body.
+* On a successful (2xx) response the returned user payload, email, and token are stored
+  in `localStorage` under the `app-user-auth` key.
+* Once authenticated the **Start recording** button becomes interactive. Attempting to
+  record while logged out automatically prompts for credentials.
+
+## Styling
+
+The record button uses a neutral, squared-off aesthetic with animated hover and active
+states. The login modal provides a focused workflow for supplying the required
+credentials.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repro Recorder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "repro-react-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.36",
+    "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useMemo, useState } from 'react';
+import { AuthModal, AuthFormValues } from './components/AuthModal';
+import { RecordButton } from './components/RecordButton';
+import { useLocalStorage } from './hooks/useLocalStorage';
+import './styles/app.css';
+
+interface AuthPayload {
+  email: string;
+  token: string;
+  userData: unknown;
+}
+
+const AUTH_STORAGE_KEY = 'app-user-auth';
+const LOGIN_ENDPOINT =
+  'http://localhost:4000/v1/apps/APP_bddcadcb-c70f-45fa-90f6-56413786f9b3/users/login';
+
+function App() {
+  const { value: auth, setValue: setAuth, remove: clearAuth } = useLocalStorage<AuthPayload | null>(
+    AUTH_STORAGE_KEY,
+    null
+  );
+
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isRecording, setRecording] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [isValidating, setValidating] = useState(false);
+
+  const isAuthenticated = useMemo(() => Boolean(auth?.token), [auth]);
+
+  const handleAuthenticate = useCallback(
+    async ({ email, token }: AuthFormValues) => {
+      setValidating(true);
+      try {
+        const response = await fetch(LOGIN_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'x-app-user-token': token
+          },
+          body: JSON.stringify({ email, token })
+        });
+
+        if (!response.ok) {
+          throw new Error('Authentication failed. Please verify your credentials.');
+        }
+
+        const payload = (await response.json()) as unknown;
+        setAuth({ email, token, userData: payload });
+        setStatusMessage('Authenticated. You can start recording.');
+      } catch (error) {
+        setStatusMessage('Authentication failed. Please try again.');
+        if (error instanceof Error) {
+          throw error;
+        }
+        throw new Error('Unexpected authentication error.');
+      } finally {
+        setValidating(false);
+      }
+    },
+    [setAuth]
+  );
+
+  const handleLogout = useCallback(() => {
+    clearAuth();
+    setRecording(false);
+    setStatusMessage('Logged out.');
+  }, [clearAuth]);
+
+  const handleRecord = useCallback(() => {
+    if (!isAuthenticated) {
+      setModalOpen(true);
+      return;
+    }
+
+    setRecording((current) => {
+      const nextState = !current;
+      setStatusMessage(nextState ? 'Recording in progress…' : 'Recording paused.');
+      return nextState;
+    });
+  }, [isAuthenticated]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>Session Recorder</h1>
+          <p className="subtitle">Authenticate to start capturing high-quality session data.</p>
+        </div>
+        <div className="header-actions">
+          {isAuthenticated ? (
+            <div className="user-chip" aria-live="polite">
+              <span className="user-indicator" aria-hidden />
+              <div className="user-text">
+                <span className="user-email">{auth?.email}</span>
+                <span className="user-subtext">Ready to record</span>
+              </div>
+              <button type="button" className="logout-button" onClick={handleLogout}>
+                Log out
+              </button>
+            </div>
+          ) : (
+            <button type="button" className="login-button" onClick={() => setModalOpen(true)}>
+              Log in
+            </button>
+          )}
+        </div>
+      </header>
+
+      <main className="app-main">
+        <section className="record-panel">
+          <RecordButton
+            isRecording={isRecording}
+            disabled={!isAuthenticated || isValidating}
+            onClick={handleRecord}
+            subtext={isAuthenticated ? (isRecording ? 'Tap to pause' : 'Tap to begin') : 'Log in required'}
+          >
+            {isRecording ? 'Recording…' : 'Start recording'}
+          </RecordButton>
+
+          <p className="status-message" role="status">
+            {isValidating
+              ? 'Validating your credentials…'
+              : statusMessage ||
+                (isAuthenticated
+                  ? 'You are authenticated. Press record to begin.'
+                  : 'Please log in to enable the recorder.')}
+          </p>
+        </section>
+      </main>
+
+      <AuthModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          if (!isValidating) {
+            setModalOpen(false);
+          }
+        }}
+        onSubmit={handleAuthenticate}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,0 +1,99 @@
+import { FormEvent, useState } from 'react';
+import '../styles/modal.css';
+
+export interface AuthFormValues {
+  email: string;
+  token: string;
+}
+
+export interface AuthModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: AuthFormValues) => Promise<void>;
+}
+
+export function AuthModal({ isOpen, onClose, onSubmit }: AuthModalProps) {
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await onSubmit({ email, token });
+      setEmail('');
+      setToken('');
+      onClose();
+    } catch (submitError) {
+      if (submitError instanceof Error) {
+        setError(submitError.message);
+      } else {
+        setError('Unable to authenticate. Please try again.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
+      <div className="modal-content">
+        <div className="modal-header">
+          <h2 id="auth-modal-title" className="modal-title">
+            Log in to start recording
+          </h2>
+          <button className="modal-close" type="button" onClick={onClose} aria-label="Close login modal">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="modal-body">
+          <div className="input-field">
+            <label htmlFor="auth-email">Email address</label>
+            <input
+              id="auth-email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              autoComplete="email"
+              placeholder="user@example.com"
+            />
+          </div>
+
+          <div className="input-field">
+            <label htmlFor="auth-token">Token</label>
+            <input
+              id="auth-token"
+              type="text"
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              required
+              autoComplete="off"
+              placeholder="Paste your access token"
+            />
+          </div>
+
+          {error ? <p className="error-message">{error}</p> : null}
+
+          <div className="modal-actions">
+            <button className="button-secondary" type="button" onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </button>
+            <button className="button-primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Authenticating…' : 'Authenticate'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecordButton.tsx
+++ b/src/components/RecordButton.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren } from 'react';
+import '../styles/record-button.css';
+
+export interface RecordButtonProps {
+  disabled?: boolean;
+  isRecording?: boolean;
+  onClick?: () => void;
+  subtext?: string;
+}
+
+export function RecordButton({
+  disabled,
+  isRecording,
+  onClick,
+  subtext,
+  children
+}: PropsWithChildren<RecordButtonProps>) {
+  return (
+    <button
+      type="button"
+      className={`record-button${isRecording ? ' recording' : ''}`}
+      disabled={disabled}
+      onClick={onClick}
+      aria-pressed={isRecording}
+    >
+      <span className="record-indicator" aria-hidden />
+      <span className="record-button-label">
+        {children}
+        {subtext ? <span className="subtext">{subtext}</span> : null}
+      </span>
+    </button>
+  );
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useLocalStorage<T>(key: string, defaultValue: T | (() => T)) {
+  const readValue = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return defaultValue instanceof Function ? defaultValue() : defaultValue;
+    }
+
+    const stored = window.localStorage.getItem(key);
+    if (stored) {
+      try {
+        return JSON.parse(stored) as T;
+      } catch (error) {
+        console.warn(`Failed to parse localStorage value for "${key}"`, error);
+      }
+    }
+
+    return defaultValue instanceof Function ? defaultValue() : defaultValue;
+  }, [defaultValue, key]);
+
+  const [value, setValue] = useState<T>(() => readValue());
+
+  useEffect(() => {
+    setValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const setStoredValue = useCallback(
+    (newValue: T | ((prev: T) => T)) => {
+      setValue((current) => {
+        const resolved = newValue instanceof Function ? newValue(current) : newValue;
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(key, JSON.stringify(resolved));
+        }
+        return resolved;
+      });
+    },
+    [key]
+  );
+
+  const remove = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(key);
+    }
+    setValue(defaultValue instanceof Function ? defaultValue() : defaultValue);
+  }, [defaultValue, key]);
+
+  return { value, setValue: setStoredValue, remove } as const;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,140 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(2rem, 5vw, 4rem);
+  color: #0f172a;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  letter-spacing: -0.03em;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  color: #475569;
+  max-width: 32rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.login-button,
+.logout-button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.login-button {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.25);
+}
+
+.login-button:hover {
+  transform: translateY(-1px);
+}
+
+.logout-button {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.logout-button:hover {
+  opacity: 0.85;
+}
+
+.user-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 0.65rem 0.8rem 0.65rem 0.65rem;
+  border-radius: 0.85rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.3);
+}
+
+.user-indicator {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 0.2rem;
+  background: #34d399;
+  box-shadow: 0 0 12px rgba(52, 211, 153, 0.65);
+}
+
+.user-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.user-email {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.user-subtext {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.app-main {
+  display: flex;
+  justify-content: center;
+}
+
+.record-panel {
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(10px);
+  border-radius: 1.5rem;
+  padding: clamp(2.5rem, 6vw, 3.5rem);
+  box-shadow: 0 32px 48px rgba(15, 23, 42, 0.1);
+  text-align: center;
+  max-width: 32rem;
+}
+
+.status-message {
+  margin-top: 1.75rem;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-actions {
+    align-self: stretch;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .user-chip {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .record-panel {
+    width: 100%;
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,20 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  color: #1f2933;
+  background-color: #f3f4f6;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #f7fafc 0%, #e2e8f0 100%);
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  font-family: inherit;
+}

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -1,0 +1,107 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  width: min(26rem, 90vw);
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  color: #6b7280;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.input-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.input-field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.input-field input {
+  padding: 0.7rem 0.9rem;
+  border-radius: 0.65rem;
+  border: 1px solid #d1d5db;
+  font-size: 0.95rem;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.input-field input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.modal-actions button {
+  border-radius: 0.65rem;
+  border: none;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.modal-actions button:active {
+  transform: translateY(1px);
+}
+
+.button-secondary {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+  color: white;
+  box-shadow: 0 8px 16px rgba(79, 70, 229, 0.25);
+}
+
+.error-message {
+  color: #dc2626;
+  font-size: 0.875rem;
+  font-weight: 500;
+}

--- a/src/styles/record-button.css
+++ b/src/styles/record-button.css
@@ -1,0 +1,65 @@
+.record-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.9rem 2.2rem;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  border-radius: 0;
+  background: linear-gradient(120deg, #475569 0%, #1f2937 100%);
+  color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 12px 28px rgba(30, 41, 59, 0.35);
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease, background 160ms ease;
+}
+
+.record-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(30, 41, 59, 0.38);
+}
+
+.record-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(30, 41, 59, 0.45);
+}
+
+.record-button:disabled {
+  cursor: not-allowed;
+  background: linear-gradient(120deg, #cbd5f5 0%, #94a3b8 100%);
+  color: #1e293b;
+  box-shadow: none;
+  border-color: rgba(148, 163, 184, 0.6);
+}
+
+.record-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 0.05rem;
+  background-color: #f97316;
+  transition: background-color 160ms ease;
+}
+
+.record-button.recording {
+  background: linear-gradient(120deg, #f97316 0%, #ea580c 100%);
+  box-shadow: 0 12px 30px rgba(249, 115, 22, 0.35);
+}
+
+.record-button.recording .record-indicator {
+  background-color: #fed7aa;
+}
+
+.record-button-label {
+  font-size: 1rem;
+}
+
+.subtext {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(248, 250, 252, 0.88);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite + React application shell for the recorder demo
- add an authentication modal and persist the successful login payload locally
- restyle the record button with a neutral, squared presentation gated by auth

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fba95973248327951cb96afaa69985